### PR TITLE
feat: change wording for versioning guidance #179942

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,13 +60,9 @@ Before submitting a pull request, please ensure that the changes have been docum
 
 ### Versioning
 
-We use a manual system where the branch is tagged and released under whatever version number has been entered in either the CSPROJ or package.json.
-Update version numbers according to the significance of the change being added (major, minor, patch, etc.).
-If you want to mark a version as `prerelease`, add `-prerelease` to the end of the version number (`1.0.1.1-prerelease` for instance). 
+All Audacia libraries follow the semantic versioning principles. Library versions are managed manually based on the value in source control, e.g. in the `package.json` or `.csproj` file.
 
-Audacia libraries previously utilised a versioning system that would automatically iterate the patch numbers.
-This would happen in instances where neither the major or minor number had been altered.
-A package would be marked as prerelease based on the branch name (a name other than `main` or `master`).
+When making changes, update the relevant version number(s) according to the significance of the change being made (major, minor, patch, etc.). If you want to mark a version as `prerelease`, add `-prerelease` to the end of the version number (`1.0.1-prerelease` for instance). 
 
 ## License
 


### PR DESCRIPTION
### Version changed and CHANGELOG updated
- ❎ No version change required

### Code ready for review
- ❎ No code changes (e.g. just a documentation change)

### Unit tests added/updated
- ❎ No code changed

### README or other documentation updated
- ✔ Documentation updated to reflect the changes made

### Added/updated logging
- ❎ No significant code changes

### Dependency licenses
- ❎ No new/upgraded dependencies